### PR TITLE
Adding compression to the example server.

### DIFF
--- a/examples/server/package.json
+++ b/examples/server/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.10.0",
+    "compression": "^1.4.4",
     "cookie-parser": "^1.3.4",
     "ejs": "^2.3.1",
     "email-templates": "^1.2.1",

--- a/examples/server/server.js
+++ b/examples/server/server.js
@@ -1,5 +1,6 @@
 // (C) Copyright 2014-2015 Hewlett-Packard Development Company, L.P.
 
+var compression = require('compression');
 var express = require('express');
 var http = require("http");
 var router = express.Router();
@@ -16,6 +17,8 @@ var path = require('path');
 var PORT = 8000;
 
 var app = express();
+
+app.use(compression());
 
 app.use(cookieParser());
 


### PR DESCRIPTION
It seems the website is using the server in `examples/server`. This pull request adds compression to the server to enable compression on the website. This is tied to #32.

[Compression](https://github.com/expressjs/compression) is MIT licensed. "I think" compression is the solution for Express 4.x. There are different things for different versions of express. For example, [here's an article covering some of them](http://inspiredjw.com/do-not-forget-to-use-gzip-for-express/).