### PR TITLE
Adding gulp dev dependencies for example server

### DIFF
--- a/examples/server/package.json
+++ b/examples/server/package.json
@@ -21,5 +21,10 @@
     "serve-static": "^1.7.1",
     "ws": "^0.7.2",
     "json-stringify-pretty-compact": "^1.0.1"
+  },
+  "devDependencies": {
+    "gulp": "^3.9.0",
+    "gulp-nodemon": "^2.0.3",
+    "gulp-rsync": "0.0.5"
   }
 }


### PR DESCRIPTION
If you install the dependencies using npm install and then try to run `gulp dev`, per the readme, there is an error of missing dependencies.

This commit adds them gulp and it's additions as dev dependencies.