### PR TITLE
Fixing license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "homepage": "http://grommet.io",
   "bugs": "https://github.com/HewlettPackard/grommet/issues",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/HewlettPackard/grommet.git"


### PR DESCRIPTION
When using `npm` commands I get the message:
```sh
$ npm install
npm WARN package.json grommet@0.2.2 license should be a valid SPDX license expression
```
This is because the license isn't keyed right. There's a [list on the SPDX site](https://spdx.org/licenses/) and this request corrects the key.