### PR TITLE
Fixed jumping buttons on home page.

### DIFF
--- a/docs/src/scss/_objects.home.scss
+++ b/docs/src/scss/_objects.home.scss
@@ -97,7 +97,6 @@ $scale-background-color-top: rgba($scale-background-color, 0.85);
 
     a.button {
       @include inuit-font-size($inuit-heading-size-3);
-      padding: halve($inuit-base-spacing-unit) $inuit-base-spacing-unit;
       color: $colored-text-color;
     }
 


### PR DESCRIPTION
The jumping caused by different padding size on hover state. 