### PR TITLE
Added new gulp task using gulp-jsx-coverage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
     "glob": "^4.3.5",
     "rewire": "^2.3.3",
     "mocha-lcov-reporter": "^0.0.2",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "gulp-jsx-coverage": "^0.1.3"
   },
   "config": {
     "blanket": {

--- a/src/utils/gulp/gulp-tasks-test.js
+++ b/src/utils/gulp/gulp-tasks-test.js
@@ -1,74 +1,70 @@
-var path = require('path');
-
 module.exports = function(gulp, options) {
+  var jsxCoverageOptions = {
+    istanbul: {
+      coverageVariable: '__MY_TEST_COVERAGE__',
+      exclude: /node_modules|test/
+    },
+    coverage: {
+      reporters: ['lcov'],
+      directory: 'coverage'
+    }
+  };
+
   gulp.task('test', function(done) {
     if (options.testPaths) {
+      var jsxCoverage = require('gulp-jsx-coverage');
       var mocha = require('gulp-mocha');
       var watch = require('gulp-watch');
       var argv = require('yargs').argv;
       require('../test/test-compiler');
       require('../test/mocked-dom')('<html><body></body></html>');
 
+      jsxCoverage.initIstanbulHook(jsxCoverageOptions);
       gulp.src(options.testPaths, {
         read: false
-      })
-        .pipe(mocha({
-          reporter: 'spec'
-        })).once('end', function() {
-        if (argv.w) {
-          var watchFolders = options.testPaths.slice();
-          options.jsAssets.forEach(function(jsAsset) {
-            watchFolders.push(jsAsset);
-          });
-          watch(watchFolders, function() {
-            gulp.src(options.testPaths, {
-              read: false
-            })
-              .pipe(mocha({
-                reporter: 'spec'
-              })).once('end', function() {
-              console.log('Watching for changes...');
-            }).on('error', function(err) {
-              console.error('Test failed:', err.stack || err);
-              if (argv.w) {
-                this.emit('end');
-              } else {
-                process.exit(1);
-              }
+      }).pipe(mocha({
+        reporter: 'spec'})).once('end', function() {
+  
+          if (argv.w) {
+            var watchFolders = options.testPaths.slice();
+            options.jsAssets.forEach(function(jsAsset) {
+              watchFolders.push(jsAsset);
             });
-          });
-          console.log('Watching for changes...');
-        } else {
-          done();
-        }
-      }).on('error', function(err) {
-        console.error('Test failed:', err.stack || err);
-        if (argv.w) {
-          this.emit('end');
-        } else {
-          process.exit(1);
-        }
-      });
+            watch(watchFolders, function() {
+              gulp.src(options.testPaths, {
+                read: false
+              })
+                .pipe(mocha({
+                  reporter: 'spec'
+                })).once('end', function() {
+                console.log('Watching for changes...');
+              }).on('error', function(err) {
+                console.error('Test failed:', err.stack || err);
+                if (argv.w) {
+                  this.emit('end');
+                } else {
+                  process.exit(1);
+                }
+              });
+            });
+            console.log('Watching for changes...');
+          } else {
+            done();
+          }
+  
+        }).on('error', function(err) {
+          console.error('Test failed:', err.stack || err);
+          if (argv.w) {
+            this.emit('end');
+          } else {
+            process.exit(1);
+          }
+        }).on('end', jsxCoverage.colloectIstanbulCoverage(jsxCoverageOptions));
     } else {
       done();
     }
   });
 
-  gulp.task('coverage', ['test'], function(done) {
-    if (options.testPaths) {
-      var blanket = require('gulp-blanket-mocha');
-      gulp.src(options.testPaths, {
-        read: false
-      })
-        .pipe(blanket({
-          instrument: [path.join(process.cwd(), 'src/js')],
-          captureFile: 'test/coverage.html',
-          reporter: 'html-cov'
-        }));
-      console.log('Done! You can checkout the report at test/coverage.html.');
-    } else {
-      console.log('No test found, please specify testPaths as an option.');
-    }
-    done();
-  });
 };
+
+


### PR DESCRIPTION
This changes **gulp test** to use istanbul instead of blanket. the [gulp-blanket-mocha](https://www.npmjs.com/package/gulp-blanket-mocha) module seems to be inactive, while [gulp-jsx-coverage](https://www.npmjs.com/package/gulp-jsx-coverage) being maintained.

This change also fixes the problem of generating the test coverage on windows #55.