### PR TITLE
Downgraded jsdom from 4.4.0 to 3.1.2 for compatibility with node 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "eslint-plugin-react": "^2.4.0",
     "babel": "^5.3.3",
     "babel-eslint": "^3.1.9",
-    "jsdom": "~4.4.0",
+    "jsdom": "~3.1.2",
     "json5": "^0.4.0",
     "react-tools": "^0.13.1",
     "run-sequence": "^1.0.2",

--- a/templates/cto-app-tuner/package.json
+++ b/templates/cto-app-tuner/package.json
@@ -62,7 +62,6 @@
     "gulp-watch": "^4.2.4",
     "webpack-stream": "^2.0.0",
     "gulp-coveralls": "^0.1.4",
-    "jsdom": "~4.4.0",
     "json5": "^0.4.0",
     "react-tools": "^0.13.1",
     "run-sequence": "^1.0.2",

--- a/templates/medium-app/package.json
+++ b/templates/medium-app/package.json
@@ -59,7 +59,6 @@
     "gulp-watch": "^4.2.4",
     "webpack-stream": "^2.0.0",
     "gulp-coveralls": "^0.1.4",
-    "jsdom": "~4.4.0",
     "json5": "^0.4.0",
     "react-tools": "^0.13.1",
     "run-sequence": "^1.0.2",

--- a/templates/todo-app-modular/package.json
+++ b/templates/todo-app-modular/package.json
@@ -62,7 +62,6 @@
     "gulp-watch": "^4.2.4",
     "webpack-stream": "^2.0.0",
     "gulp-coveralls": "^0.1.4",
-    "jsdom": "~4.4.0",
     "json5": "^0.4.0",
     "react-tools": "^0.13.1",
     "run-sequence": "^1.0.2",


### PR DESCRIPTION
Just downgraded jsdom from 4.4.0 to 3.1.2 and now grommet can be built with node 0.10. Also removed jsdom from the templates dependencies.