### PR TITLE
Switched jsdom to jsdom-no-contextify to avoid python dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "eslint-plugin-react": "^2.4.0",
     "babel": "^5.3.3",
     "babel-eslint": "^3.1.9",
-    "jsdom": "~3.1.2",
+    "jsdom-no-contextify": "~3.1.0",
     "json5": "^0.4.0",
     "react-tools": "^0.13.1",
     "run-sequence": "^1.0.2",

--- a/src/utils/test/mocked-dom.js
+++ b/src/utils/test/mocked-dom.js
@@ -5,7 +5,7 @@ module.exports = function(markup) {
     return;
   }
 
-  var jsdom = require("jsdom").jsdom;
+  var jsdom = require("jsdom-no-contextify").jsdom;
   global.document = jsdom(markup || '');
   global.window = document.defaultView;
   global.navigator = {


### PR DESCRIPTION
With this change we can build grommet on windows without depending on python.