### PR TITLE
Switch from jsx loader to babel

### DIFF
--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -63,7 +63,7 @@ var opts = {
       loaders: [
         {
           test: /develop(\/|\\).*\.htm$|design(\/|\\)[^\/]*\.htm$|design(\/|\\).*\/.*\.htm$/,
-          loader: 'jsx-loader!imports?React=react,Router=react-router,Link=>Router.Link!html-jsx-loader'
+          loader: 'babel!imports?React=react,Router=react-router,Link=>Router.Link!html-jsx-loader'
         }
       ]
     }

--- a/docs/hpe/gulpfile.js
+++ b/docs/hpe/gulpfile.js
@@ -47,7 +47,7 @@ var opts = {
       loaders: [
         {
           test: /develop(\/|\\).*\.htm$|design(\/|\\)[^\/]*\.htm$|design(\/|\\).*\/.*\.htm$/,
-          loader: 'jsx-loader!imports?React=react,Router=react-router,Link=>Router.Link!html-jsx-loader'
+          loader: 'babel!imports?React=react,Router=react-router,Link=>Router.Link!html-jsx-loader'
         }
       ]
     }

--- a/docs/hpinc/gulpfile.js
+++ b/docs/hpinc/gulpfile.js
@@ -47,7 +47,7 @@ var opts = {
       loaders: [
         {
           test: /develop(\/|\\).*\.htm$|design(\/|\\)[^\/]*\.htm$|design(\/|\\).*\/.*\.htm$/,
-          loader: 'jsx-loader!imports?React=react,Router=react-router,Link=>Router.Link!html-jsx-loader'
+          loader: 'babel!imports?React=react,Router=react-router,Link=>Router.Link!html-jsx-loader'
         }
       ]
     }

--- a/gulpfile-grommet-dist.js
+++ b/gulpfile-grommet-dist.js
@@ -34,7 +34,7 @@ var bowerWebpackConfig = {
     loaders: [
       {
         test: /\.js$/,
-        loader: 'jsx-loader'
+        loader: 'babel'
       },
       {
         test: /\.json$/,

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "file-loader": "^0.8.1",
     "imports-loader": "^0.6.3",
     "html-jsx-loader": "^0.1.12",
-    "jsx-loader": "0.13.1",
+    "babel-loader": "^5.2.2",
     "sass-loader": "^0.4.2",
     "style-loader": "^0.12.0",
     "json-loader": "^0.5.1",

--- a/src/utils/gulp/gulp-tasks.js
+++ b/src/utils/gulp/gulp-tasks.js
@@ -15,7 +15,8 @@ var webpackConfig = {
     loaders: [
       {
         test: /\.js$/,
-        loader: 'jsx-loader'
+        loader: 'babel',
+        exclude: /(node_modules|bower_components|src\/lib)/
       },
       {
         test: /\.json$/,

--- a/templates/cto-app-tuner/package.json
+++ b/templates/cto-app-tuner/package.json
@@ -43,7 +43,7 @@
     "file-loader": "^0.8.1",
     "imports-loader": "^0.6.3",
     "html-jsx-loader": "^0.1.12",
-    "jsx-loader": "0.13.1",
+    "babel-loader": "^5.2.2",
     "sass-loader": "^0.4.2",
     "style-loader": "^0.10.1",
     "gulp": "^3.8.11",

--- a/templates/init/package.json
+++ b/templates/init/package.json
@@ -47,7 +47,7 @@
     "webpack": "1.9.10",
     "webpack-dev-server": "^1.8.0",
     "object-assign": "^2.0.0",
-    "jsx-loader": "0.13.1",
+    "babel-loader": "^5.2.2",
     "css-loader": "^0.10.1",
     "sass-loader": "^0.4.2",
     "style-loader": "^0.10.1",

--- a/templates/medium-app/package.json
+++ b/templates/medium-app/package.json
@@ -40,7 +40,7 @@
     "file-loader": "^0.8.1",
     "imports-loader": "^0.6.3",
     "html-jsx-loader": "^0.1.12",
-    "jsx-loader": "0.13.1",
+    "babel-loader": "^5.2.2",
     "sass-loader": "^0.4.2",
     "style-loader": "^0.10.1",
     "gulp": "^3.8.11",

--- a/templates/todo-app-modular/package.json
+++ b/templates/todo-app-modular/package.json
@@ -43,7 +43,7 @@
     "file-loader": "^0.8.1",
     "imports-loader": "^0.6.3",
     "html-jsx-loader": "^0.1.12",
-    "jsx-loader": "0.13.1",
+    "babel-loader": "^5.2.2",
     "sass-loader": "^0.4.2",
     "style-loader": "^0.10.1",
     "gulp": "^3.8.11",


### PR DESCRIPTION
This PR aims to move from jsx loader to babel, which is now the recommended way to transpile future JS code.