### PR TITLE
Added defaults for font family and updated themes to specify default font

### DIFF
--- a/src/scss/grommet-core/_base.font.scss
+++ b/src/scss/grommet-core/_base.font.scss
@@ -1,40 +1,5 @@
 // (C) Copyright 2014-2015 Hewlett-Packard Development Company, L.P.
 
-//@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,400italic);
-// Include inline so we can use local fonts if available without network requests.
-@font-face {
-  font-family: 'Source Sans Pro';
-  font-style: normal;
-  font-weight: 300;
-  src: local('Source Sans Pro Light'),
-    local('SourceSansPro-Light'),
-    url(http://fonts.gstatic.com/s/sourcesanspro/v9/toadOcfmlt9b38dHJxOBGPS42wKzre0cxmO5m5GyTsY.ttf) format('truetype');
-}
-@font-face {
-  font-family: 'Source Sans Pro';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Source Sans Pro'),
-    local('SourceSansPro-Regular'),
-    url(http://fonts.gstatic.com/s/sourcesanspro/v9/ODelI1aHBYDBqgeIAH2zlEY6Fu39Tt9XkmtSosaMoEA.ttf) format('truetype');
-}
-@font-face {
-  font-family: 'Source Sans Pro';
-  font-style: normal;
-  font-weight: 700;
-  src: local('Source Sans Pro Bold'),
-    local('SourceSansPro-Bold'),
-    url(http://fonts.gstatic.com/s/sourcesanspro/v9/toadOcfmlt9b38dHJxOBGLlcMrNrsnL9dgADnXgYJjs.ttf) format('truetype');
-}
-@font-face {
-  font-family: 'Source Sans Pro';
-  font-style: italic;
-  font-weight: 400;
-  src: local('Source Sans Pro Italic'),
-    local('SourceSansPro-It'),
-    url(http://fonts.gstatic.com/s/sourcesanspro/v9/M2Jd71oPJhLKp0zdtTvoMzpKUtbt71woJ25xl7KOGD0.ttf) format('truetype');
-}
-
 html {
-  font-family: 'Source Sans Pro', Arial, sans-serif;
+  font-family: $brand-font-family;
 }

--- a/src/scss/grommet-core/_base.font.scss
+++ b/src/scss/grommet-core/_base.font.scss
@@ -1,5 +1,6 @@
 // (C) Copyright 2014-2015 Hewlett-Packard Development Company, L.P.
 
-html {
+html, 
+.brand-font {
   font-family: $brand-font-family;
 }

--- a/src/scss/grommet-core/_settings.font.scss
+++ b/src/scss/grommet-core/_settings.font.scss
@@ -1,0 +1,36 @@
+// (C) Copyright 2014-2015 Hewlett-Packard Development Company, L.P.
+
+$brand-font-family: 'Source Sans Pro', Arial, sans-serif !default;
+
+@font-face {
+  font-family: 'Source Sans Pro';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Source Sans Pro Light'),
+    local('SourceSansPro-Light'),
+    url(http://fonts.gstatic.com/s/sourcesanspro/v9/toadOcfmlt9b38dHJxOBGPS42wKzre0cxmO5m5GyTsY.ttf) format('truetype');
+}
+@font-face {
+  font-family: 'Source Sans Pro';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Source Sans Pro'),
+    local('SourceSansPro-Regular'),
+    url(http://fonts.gstatic.com/s/sourcesanspro/v9/ODelI1aHBYDBqgeIAH2zlEY6Fu39Tt9XkmtSosaMoEA.ttf) format('truetype');
+}
+@font-face {
+  font-family: 'Source Sans Pro';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Source Sans Pro Bold'),
+    local('SourceSansPro-Bold'),
+    url(http://fonts.gstatic.com/s/sourcesanspro/v9/toadOcfmlt9b38dHJxOBGLlcMrNrsnL9dgADnXgYJjs.ttf) format('truetype');
+}
+@font-face {
+  font-family: 'Source Sans Pro';
+  font-style: italic;
+  font-weight: 400;
+  src: local('Source Sans Pro Italic'),
+    local('SourceSansPro-It'),
+    url(http://fonts.gstatic.com/s/sourcesanspro/v9/M2Jd71oPJhLKp0zdtTvoMzpKUtbt71woJ25xl7KOGD0.ttf) format('truetype');
+}

--- a/src/scss/grommet-core/index.scss
+++ b/src/scss/grommet-core/index.scss
@@ -4,6 +4,7 @@
 @import "inuit-defaults/settings.defaults";
 @import "settings.defaults";
 @import "settings.color";
+@import "settings.font";
 @import "inuit-responsive-settings/settings.responsive";
 
 // Tools

--- a/src/scss/hpe/_hpe.defaults.scss
+++ b/src/scss/hpe/_hpe.defaults.scss
@@ -45,11 +45,6 @@ $brand-graph-colors: (#FF8D6D, #877B75, #2AD2C9, #614767, #617D78);
   src: url("~grommet/scss/hpe/font/SimRg.otf") format("opentype");
 }
 
-html,
-.brand-font {
-  font-family: $brand-font-family; 
-}
-
 .large-number-font {
   font-family: 'Simple', 'Metric', Arial, sans-serif;
 }

--- a/src/scss/hpe/_hpe.defaults.scss
+++ b/src/scss/hpe/_hpe.defaults.scss
@@ -1,5 +1,6 @@
 // (C) Copyright 2014-2015 Hewlett-Packard Development Company, L.P.
 
+$brand-font-family: 'Metric', Arial, sans-serif;
 $brand-color: #00B388;
 $brand-color-lighter: desaturate(lighten($brand-color, 55%), 40%);
 $brand-neutral-colors: (#60798D, #617D78, #877B75);
@@ -46,7 +47,7 @@ $brand-graph-colors: (#FF8D6D, #877B75, #2AD2C9, #614767, #617D78);
 
 html,
 .brand-font {
-  font-family: 'Metric', Arial, sans-serif;
+  font-family: $brand-font-family; 
 }
 
 .large-number-font {

--- a/src/scss/hpinc/_hpinc.defaults.scss
+++ b/src/scss/hpinc/_hpinc.defaults.scss
@@ -22,11 +22,6 @@ $focus-border-color: #99d5ef;
   src: url("~grommet/scss/hpinc/font/hps-me-w27-regular-woff.woff") format('woff');
 }
 
-html,
-.brand-font {
-  font-family: $brand-font-family;
-}
-
 .control-icon {
   path,
   line,

--- a/src/scss/hpinc/_hpinc.defaults.scss
+++ b/src/scss/hpinc/_hpinc.defaults.scss
@@ -1,5 +1,6 @@
 // (C) Copyright 2014-2015 Hewlett-Packard Development Company, L.P.
 
+$brand-font-family: 'HPSimplified', Arial, sans-serif;
 $brand-color: #0096D6;
 $brand-color-lighter: desaturate(lighten($brand-color, 50%), 20%);
 $brand-neutral-colors: (#545454, #767676, #989898);
@@ -23,7 +24,7 @@ $focus-border-color: #99d5ef;
 
 html,
 .brand-font {
-  font-family: 'HPSimplified', Arial, sans-serif;
+  font-family: $brand-font-family;
 }
 
 .control-icon {


### PR DESCRIPTION
Without this, apps created with the `grommet init` command will not change to the correct font when changing themes.