### PR TITLE
Added lang attr to html tag and grommet App.

### DIFF
--- a/src/js/components/App.js
+++ b/src/js/components/App.js
@@ -3,6 +3,7 @@
 var React = require('react');
 
 var IntlMixin = require('../mixins/GrommetIntlMixin');
+var Locale = require('../utils/Locale');
 
 var App = React.createClass({
 
@@ -26,8 +27,14 @@ var App = React.createClass({
     if (this.props.inline) {
       classes.push("app--inline");
     }
+
     if (this.props.className) {
       classes.push(this.props.className);
+    }
+
+    var lang = Locale.getCurrentLocale();
+    if (this.props.lang) {
+      lang = this.props.lang;
     }
 
     //remove this when React 0.14 is released. This is required because context props are not being propagated to children.
@@ -39,8 +46,12 @@ var App = React.createClass({
       }
     }.bind(this));
 
+    if (!document.documentElement.getAttribute('lang')) {
+      document.documentElement.setAttribute('lang', lang);
+    }
+
     return (
-      <div className={classes.join(' ')}>
+      <div lang={lang} className={classes.join(' ')}>
         {children}
       </div>
     );

--- a/src/js/utils/Locale.js
+++ b/src/js/utils/Locale.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2015 Hewlett-Packard Development Company, L.P.
 var merge = require('lodash/object/merge');
 var Cookies = require('./Cookies');
+var fallbackLocale = 'en-US';
 
 function normalizeLocale(locale) {
   var locales = locale.replace(/_/g, '-').split('-');
@@ -20,7 +21,7 @@ module.exports = {
       locale = window.navigator.languages ? window.navigator.languages[0] : (window.navigator.language || window.navigator.userLanguage);
     }
 
-    return normalizeLocale(locale);
+    return normalizeLocale(locale || fallbackLocale);
   },
 
   getLocaleData: function(appLocale) {
@@ -30,7 +31,7 @@ module.exports = {
       grommetMessages = require('../messages/' + locale);
     } catch (e) {
       console.warn(locale + ' not supported, fallback to English has been applied.');
-      locale = 'en-US';
+      locale = fallbackLocale;
       grommetMessages = require('../messages/en-US');
     }
 

--- a/templates/init/src/index.html
+++ b/templates/init/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <title><%= appTitle %></title>


### PR DESCRIPTION
This PR adds the lang attribute to the App grommet component and to the html tag as suggested but the [WCAG 2.0 guidelines](http://www.w3.org/TR/WCAG20-TECHS/H57.html). 

If no lang attribute is passed to the App component, it gets the default locale from the browser. Also, the App component sets the lang attribute to the html tag if it is not set.