### PR TITLE
Updating the font CDN to use https.

### DIFF
--- a/src/scss/hpe/_hpe.defaults.scss
+++ b/src/scss/hpe/_hpe.defaults.scss
@@ -17,7 +17,7 @@ $brand-text-decoration: underline solid $brand-color;
 $brand-grey-colors: (#333333, #3B3B3B, #434343, #666666);
 $brand-graph-colors: (#FF8D6D, #877B75, #2AD2C9, #614767, #617D78);
 
-$hpe-fonts-path: "http://hpefonts.s3.amazonaws.com";
+$hpe-fonts-path: "https://hpefonts.s3.amazonaws.com";
 
 @font-face {
   font-family: "Metric";

--- a/src/scss/hpinc/_hpinc.defaults.scss
+++ b/src/scss/hpinc/_hpinc.defaults.scss
@@ -17,7 +17,7 @@ $brand-grey-colors: (#545454, #767676, #989898);
 $brand-graph-colors: (#0096D6, #C094bf, #99d5ef, #87898b, #b9b8bb);
 $focus-border-color: #99d5ef;
 
-$hpinc-fonts-path: "http://hpincfonts.s3.amazonaws.com";
+$hpinc-fonts-path: "https://hpincfonts.s3.amazonaws.com";
 
 @font-face {
   font-family: "HPSimplified";


### PR DESCRIPTION
Since applications will be running behind https a useful default
is to set the CDN to use https. This will help to have all assets
served that way. It will also help with https everywhere which is
useful.