### PR TITLE
Converting Calendar componend to use virtual DOM document.

### DIFF
--- a/src/js/components/Calendar.js
+++ b/src/js/components/Calendar.js
@@ -142,6 +142,7 @@ var Calendar = React.createClass({
       enter: this._onSelectDate,
       space: this._onSelectDate
     };
+    var document = React.findDOMNode(this).ownerDocument;
 
     if (dropActive) {
 


### PR DESCRIPTION
The document object isn't available in node.js causing the component
to break if rendered server side. Using the virtual DOM rather than
the browser DOM appears to work as an alternative.