### PR TITLE
Refactoring addressing the comments from @ericsoderberghp

### DIFF
--- a/src/js/components/Article.js
+++ b/src/js/components/Article.js
@@ -16,7 +16,7 @@ var Article = React.createClass({
 
   propTypes: merge({
     scrollStep: React.PropTypes.bool,
-    primary: true
+    primary: React.PropTypes.bool
   }, Box.propTypes),
 
   mixins: [KeyboardAccelerators],
@@ -136,7 +136,7 @@ var Article = React.createClass({
 
     var skipLinkAnchor = null;
     if (this.props.primary) {
-      skipLinkAnchor = <SkipLinkAnchor label="Footer" />;
+      skipLinkAnchor = <SkipLinkAnchor label="Main Content" />;
     }
     return (
       <Box ref="component" tag="article" {...other} className={classes.join(' ')}>

--- a/src/js/components/Section.js
+++ b/src/js/components/Section.js
@@ -2,12 +2,16 @@
 
 var React = require('react');
 var Box = require('./Box');
+var SkipLinkAnchor = require('./SkipLinkAnchor');
+var merge = require('lodash/object/merge');
 
 var CLASS_ROOT = "section";
 
 var Section = React.createClass({
 
-  propTypes: Box.propTypes,
+  propTypes: merge(Box.propTypes, {
+    primary: React.PropTypes.bool
+  }),
 
   getDefaultProps: function () {
     return {pad: {vertical: 'medium'}};
@@ -19,8 +23,14 @@ var Section = React.createClass({
       classes.push(this.props.className);
     }
 
+    var skipLinkAnchor = null;
+    if (this.props.primary) {
+      skipLinkAnchor = <SkipLinkAnchor label="Main Content" />;
+    }
+
     return (
       <Box tag="section" {...this.props} className={classes.join(' ')}>
+        {skipLinkAnchor}
         {this.props.children}
       </Box>
     );

--- a/src/js/components/SkipLinkAnchor.js
+++ b/src/js/components/SkipLinkAnchor.js
@@ -14,7 +14,7 @@ var SkipLinkAnchor = React.createClass({
   render: function () {
     var id = 'skip-link-' + this.props.label.toLowerCase().replace(/ /g, '_');
     return (
-      <div tabIndex="0" id={id} data-skip-label={this.getGrommetIntlMessage(this.props.label)} className="skip-link-anchor" />
+      <a tabIndex="-1" id={id} data-skip-label={this.getGrommetIntlMessage(this.props.label)} className="skip-link-anchor" />
     );
   }
 

--- a/src/js/components/SkipLinks.js
+++ b/src/js/components/SkipLinks.js
@@ -11,8 +11,7 @@ var SkipLinks = React.createClass({
   mixins: [IntlMixin],
 
   componentDidMount: function () {
-    var _document = React.findDOMNode(this).ownerDocument;
-    var anchorElements = _document.querySelectorAll('[data-skip-label]');
+    var anchorElements = document.querySelectorAll('[data-skip-label]');
 
     var anchors = Array.prototype.map.call(anchorElements, function (anchorElement) {
       return {
@@ -36,13 +35,19 @@ var SkipLinks = React.createClass({
 
   _onBlur: function (event) {
     setTimeout(function () {
-      var _document = React.findDOMNode(this).ownerDocument;
       var skipLinksLayer = this.refs.skipLinksLayer.getDOMNode();
-      var activeElement = _document.activeElement;
+      var activeElement = document.activeElement;
       if (!DOM.isDescendant(skipLinksLayer, activeElement)) {
         this.setState({showLayer: false});
       }
     }.bind(this));
+  },
+
+  _onClick: function (destId) {
+    return function (event) {
+      var dest = document.getElementById(destId);
+      dest.focus();
+    };
   },
 
   render: function () {
@@ -52,6 +57,7 @@ var SkipLinks = React.createClass({
            href={'#' + anchor.id}
            onFocus={this._onFocus}
            onBlur={this._onBlur}
+           onClick={this._onClick(anchor.id)}
            key={anchor.id}
            aria-label={this.getGrommetIntlMessage('Skip to') + ' ' + anchor.label}>
           {anchor.label}

--- a/src/scss/grommet-core/_tools.flexible.scss
+++ b/src/scss/grommet-core/_tools.flexible.scss
@@ -14,7 +14,7 @@
           width: 0;
           margin: 0;
           padding: 0;
-        }  
+        }
       }
     }
   }


### PR DESCRIPTION
- Using <a> instead of <div> on SkipLinksAnchor (@ericsoderberghp suggestion)
- SkipLinkAnchor moved from Box to Article/Section (@ericsoderberghp suggestion)
- Added tabIndex -1 to SkipLinksAnchors as suggested in [A Skip Link Primer](http://viget.com/inspire/skip-link-primer)
- Using .focus() when moving to the anchor as suggested in [A Skip Link Primer](http://viget.com/inspire/skip-link-primer)
- Removed trailing white space from scss file.