### PR TITLE
Updating SkipLinks when changing route.

### DIFF
--- a/src/js/components/SkipLinks.js
+++ b/src/js/components/SkipLinks.js
@@ -10,7 +10,7 @@ var SkipLinks = React.createClass({
 
   mixins: [IntlMixin],
 
-  componentDidMount: function () {
+  _updateAnchors: function () {
     var anchorElements = document.querySelectorAll('[data-skip-label]');
 
     var anchors = Array.prototype.map.call(anchorElements, function (anchorElement) {
@@ -21,6 +21,21 @@ var SkipLinks = React.createClass({
     });
 
     this.setState({anchors: anchors});
+  },
+
+  componentDidMount: function () {
+    this._updateAnchors();
+  },
+
+  componentWillReceiveProps: function (newProps) {
+    this.setState({routeChanged: true});
+  },
+
+  componentDidUpdate: function () {
+    if (this.state.routeChanged) {
+      this._updateAnchors();
+      this.setState({routeChanged: false});
+    }
   },
 
   getInitialState: function () {


### PR DESCRIPTION
This PR fix #113. The reason this is happening is that the `componentDidMount` method is not called when a react-router dynamic segments are used. React-router suggest implementing also `componentWillReceiveProps` (See [React Router Guide](https://github.com/rackt/react-router/blob/0.13.x/docs/guides/overview.md)).