### PR TITLE
Removed redundant links in the Grommet docs header.

### DIFF
--- a/docs/src/DocsHeader.js
+++ b/docs/src/DocsHeader.js
@@ -19,9 +19,7 @@ var DocsHeader = React.createClass({
         appCentered={true} justify="between">
         <Title responsive={false}>
           <Link to="docs">
-            <GrommetLogo small={true} />
-          </Link>
-          <Link to="docs">
+            <GrommetLogo small={true} a11y-title=""/>
             Grommet
           </Link>
         </Title>


### PR DESCRIPTION
Improved the keyboard and screen reader access to Grommet Docs.  Put both Grommet logo and text in the same link and made the `a11y-title` of the Grommet logo image `null`.  (In this context the Grommet logo is decorative)