### PR TITLE
Removed redundant links in the Grommet docs header.

### DIFF
--- a/docs/src/DocsHeader.js
+++ b/docs/src/DocsHeader.js
@@ -19,9 +19,7 @@ var DocsHeader = React.createClass({
         appCentered={true} justify="between">
         <Title responsive={false}>
           <Link to="docs">
-            <GrommetLogo small={true} />
-          </Link>
-          <Link to="docs">
+            <GrommetLogo small={true} a11yTitle=""/>
             Grommet
           </Link>
         </Title>


### PR DESCRIPTION
This minor change improves screen reader access to the Grommet Docs.  Both the logo and the Grommet text in the heading were link same location and would cause screen readers to read "Grommet twice".  It is now fixed.