### PR TITLE
fix #75 Datepicker - selected date differs one day from shown date

### DIFF
--- a/src/js/components/Calendar.js
+++ b/src/js/components/Calendar.js
@@ -26,7 +26,7 @@ var Calendar = React.createClass({
 
   getDefaultProps: function () {
     return {
-      value: (new Date()).toISOString().slice(0, 10)
+      value: moment().format('YYYY-MM-DD')
     };
   },
 
@@ -47,7 +47,7 @@ var Calendar = React.createClass({
 
   _onClickDay: function (date) {
     if (this.props.onChange) {
-      this.props.onChange(date.toISOString().slice(0, 10));
+      this.props.onChange(moment(date).format('YYYY-MM-DD'));
     }
   },
 


### PR DESCRIPTION
The bug is caused by the method toISOString, which returns a string representation of a date having the timezone zero UTC offset, as denoted by the suffix "Z".
On the other hand, the calendar is populated with dates having the timezone of the user's machine.
That's why Tue Jul 07 2015 00:00:00 GMT+0300 becomes 2015-07-06T21:00:00.000Z.
I replaced date.toISOString().slice(0, 10) with moment(date).format('YYYY-MM-DD') and it works ok right now.