### PR TITLE
Non-selectable Lists

### DIFF
--- a/src/js/components/List.js
+++ b/src/js/components/List.js
@@ -105,6 +105,7 @@ var List = React.createClass({
       var primary;
       var secondary;
       var selected;
+      var onClick;
 
       this.props.schema.forEach(function (scheme) {
         if (scheme.image) {
@@ -122,10 +123,14 @@ var List = React.createClass({
         }
       }, this);
 
+      if (this.props.onSelect) {
+        onClick = this._onClickItem.bind(this, item);
+      }
+
       return (
         <ListItem key={uid} image={image} label={primary}
           annotation={secondary} selected={selected}
-          onClick={this._onClickItem.bind(this, item)} />
+          onClick={onClick} />
       );
     }, this);
 

--- a/test/components/ListItem-test.js
+++ b/test/components/ListItem-test.js
@@ -1,0 +1,54 @@
+// (C) Copyright 2014-2015 Hewlett-Packard Development Company, L.P.
+
+var path = require('path');
+var __path__ = path.join(__dirname, '../../src/js/components/ListItem');
+
+var GrommetTestUtils = require('../../src/utils/test/GrommetTestUtils');
+
+describe('Grommet ListItem', function() {
+  it('loads a basic ListItem', function() {
+    var Component = GrommetTestUtils.getComponent(__path__, null,
+      {label: 'primary',
+        annotation: 'secondary'});
+
+    GrommetTestUtils.componentShouldExist(Component, 'list-item');
+    GrommetTestUtils.componentShouldNotExist(Component, 'list-item--selected');
+    GrommetTestUtils.componentShouldNotExist(Component, 'list-item--selectable');
+  });
+
+  it('loads a selectable ListItem', function() {
+    var Component = GrommetTestUtils.getComponent(__path__, null,
+      {label: 'primary',
+        annotation: 'secondary',
+        onClick: function () {
+          console.log('clicked');
+        }});
+
+    GrommetTestUtils.componentShouldExist(Component, 'list-item');
+    GrommetTestUtils.componentShouldNotExist(Component, 'list-item--selected');
+    GrommetTestUtils.componentShouldExist(Component, 'list-item--selectable');
+  });
+
+  it('loads a selected ListItem', function() {
+    var Component = GrommetTestUtils.getComponent(__path__, null,
+      {label: 'primary',
+        annotation: 'secondary',
+        selected: true});
+
+    GrommetTestUtils.componentShouldExist(Component, 'list-item');
+    GrommetTestUtils.componentShouldExist(Component, 'list-item--selected');
+    GrommetTestUtils.componentShouldNotExist(Component, 'list-item--selectable');
+  });
+
+  it('loads a customized ListItem', function() {
+    var Component = GrommetTestUtils.getComponent(__path__, null,
+      {label: 'primary',
+        annotation: 'secondary',
+        className: 'test'});
+
+    GrommetTestUtils.componentShouldExist(Component, 'list-item');
+    GrommetTestUtils.componentShouldExist(Component, 'test');
+    GrommetTestUtils.componentShouldNotExist(Component, 'list-item--selected');
+    GrommetTestUtils.componentShouldNotExist(Component, 'list-item--selectable');
+  });
+});


### PR DESCRIPTION
This PR enables non-selectable lists. Currently, all ListItems have the class `list-item--selectable` whether or not the property `onSelected` of the List component is set. Due to assigning `this._onClickItem.bind(this, item)` to all ListItems (see [code](https://github.com/HewlettPackard/grommet/blob/master/src/js/components/List.js#L128)), the onClick property of each ListItem is always truthy and thus the class `list-item--selectable` is assigned (see [code](https://github.com/HewlettPackard/grommet/blob/master/src/js/components/ListItem.js#L19-L21)).

This PR assigns `this._onClickItem.bind(this, item)` only if the onSelected property of the list is set.

Signed-off-by: Tobias Kahse <tobias.kahse@hp.com>