### PR TITLE
Css fixes

### DIFF
--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -83,6 +83,7 @@ $form-vertical-padding: quarter($inuit-base-spacing-unit);
 
     // Prevent textarea from adding extra bottom margin
     > textarea {
+      resize: vertical;
       vertical-align: top;
       height: auto;
     }

--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -107,7 +107,6 @@ $form-vertical-padding: quarter($inuit-base-spacing-unit);
 
     // Prevent textarea from adding extra bottom margin
     > textarea {
-      resize: vertical;
       vertical-align: top;
       height: auto;
     }

--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -89,6 +89,22 @@ $form-vertical-padding: quarter($inuit-base-spacing-unit);
       text-shadow: 0 0 0 #000;
     }
 
+    // Disable IE's clear icon
+    ::-ms-clear {
+      display: none;
+    }
+
+    // Disable IE's select arrow
+    > select::-ms-expand {
+      display: none;
+    }
+
+    // Disable IE's background select
+    > select::-ms-value {
+      background: none;
+      color: inherit;
+    }
+
     // Prevent textarea from adding extra bottom margin
     > textarea {
       resize: vertical;

--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -83,6 +83,12 @@ $form-vertical-padding: quarter($inuit-base-spacing-unit);
       padding-left: #{$form-horizontal-padding - 2};
     }
 
+    // For dotted firefox outline
+    > select:-moz-focusring {
+      color: transparent;
+      text-shadow: 0 0 0 #000;
+    }
+
     // Prevent textarea from adding extra bottom margin
     > textarea {
       resize: vertical;

--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -109,6 +109,8 @@ $form-vertical-padding: quarter($inuit-base-spacing-unit);
     > textarea {
       vertical-align: top;
       height: auto;
+      // Note that resize does nothing in IE and android
+      resize: vertical;
     }
 
     > .check-box,

--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -78,8 +78,9 @@ $form-vertical-padding: quarter($inuit-base-spacing-unit);
 
     > select {
       display: block;
-      // TODO figure out how to make this consistent with intuit and not have magic numbers
-      background-position: center right #{$form-horizontal-padding - 6};
+      background-position: center right #{$form-horizontal-padding - quarter($inuit-base-spacing-unit)};
+      // This seems to be correct for only some browsers.
+      // Extra whitespace is added (by different amounts) by each browser's rendering engine
       padding-left: #{$form-horizontal-padding - 2};
     }
 

--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -109,7 +109,7 @@ $form-vertical-padding: quarter($inuit-base-spacing-unit);
     > textarea {
       vertical-align: top;
       height: auto;
-      // Note that resize does nothing in IE and android
+      // Note that resize does nothing in IE/Edge
       resize: vertical;
     }
 

--- a/src/scss/grommet-core/_objects.form-field.scss
+++ b/src/scss/grommet-core/_objects.form-field.scss
@@ -78,7 +78,9 @@ $form-vertical-padding: quarter($inuit-base-spacing-unit);
 
     > select {
       display: block;
-      background-position: center right $form-horizontal-padding;
+      // TODO figure out how to make this consistent with intuit and not have magic numbers
+      background-position: center right #{$form-horizontal-padding - 6};
+      padding-left: #{$form-horizontal-padding - 2};
     }
 
     // Prevent textarea from adding extra bottom margin


### PR DESCRIPTION
This fixes #141, #142, and #143 

Additionally 
gets rid of the dotted line around select boxes in firefox.
Only allows resize of textarea vertically (in browsers that support [resize](http://caniuse.com/#feat=css-resize))
fixes IE x on all inputs not just search

I do not like my -6 and -2 in the css, are there better things to take those numbers from?