### PR TITLE
Addressing issue #53 allowing type of button to be set.

### DIFF
--- a/docs/src/develop/components/ButtonDoc.js
+++ b/docs/src/develop/components/ButtonDoc.js
@@ -36,9 +36,12 @@ var ButtonDoc = React.createClass({
           <dt><code>primary        true|false</code></dt>
           <dd>Whether this is a primary button. There should be at most
             one per page or screen.</dd>
-          </dl>
-          <dt><code>large         true|false</code></dt>
+          <dt><code>large          true|false</code></dt>
           <dd>Whether this is a large button. Defaults to false.</dd>
+          <dt><code>type           button|reset|submit</code></dt>
+          <dd>The type of button. Set the type to <code>submit</code>
+              for the default button on forms.  Defaults to <code>button</code>.</dd>
+          </dl>
         </section>
 
         <section>

--- a/src/js/components/Button.js
+++ b/src/js/components/Button.js
@@ -12,7 +12,14 @@ var Button = React.createClass({
     large: React.PropTypes.bool,
     onClick: React.PropTypes.func,
     primary: React.PropTypes.bool,
+    type: React.PropTypes.string,
     id: React.PropTypes.string
+  },
+
+  getDefaultProps: function () {
+    return {
+      type: "button"
+    };
   },
 
   render: function () {
@@ -34,7 +41,7 @@ var Button = React.createClass({
     }
 
     return (
-      <button id={this.props.id} className={classes.join(' ')}
+      <button id={this.props.id} type={this.props.type} className={classes.join(' ')}
         onClick={this.props.onClick}>
         {this.props.label}
       </button>


### PR DESCRIPTION
Tested by changing order of buttons on Todo-app-modular; before this change pressing enter on the form would cancel instead of submit.  After this change, regardless of button order, pressing enter on form will submit form.
Signed-off-by: Bryan Jacquot <jacquot@hp.com>