### PR TITLE
Gulp poll for vm hosted grommet projects

### DIFF
--- a/src/utils/gulp/gulp-tasks-dev.js
+++ b/src/utils/gulp/gulp-tasks-dev.js
@@ -69,9 +69,6 @@ module.exports = function(gulp, options, webpackConfig, dist) {
         colors: true
       },
       publicPath: devWebpackConfig.output.publicPath,
-      watchOptions: {
-        poll: true
-      },
       historyApiFallback: true
     };
 

--- a/src/utils/gulp/gulp-tasks-dev.js
+++ b/src/utils/gulp/gulp-tasks-dev.js
@@ -69,8 +69,15 @@ module.exports = function(gulp, options, webpackConfig, dist) {
         colors: true
       },
       publicPath: devWebpackConfig.output.publicPath,
+      watchOptions: {
+        poll: true
+      },
       historyApiFallback: true
     };
+
+    if (options.watchOptions) {
+      devServerConfig.watchOptions = options.watchOptions;
+    }
 
     if (options.devServerProxy) {
       devServerConfig.proxy = options.devServerProxy;


### PR DESCRIPTION
If people are running npm in a vm, but editing on the host webpack does not see the changes via inotify.
This change allows folks to poll if they want by simply putting

watchOptions: {
  poll: true
}

into their gulpfile.

My tests showed it was rather inefficient and consumed a fair bit of CPU cycles.
Once
https://github.com/webpack/watchpack/issues/2
is fixed we should be good, although I still probably wouldn't enable it by default.