### PR TITLE
Open all host ports by default for `gulp dev`

### DIFF
--- a/src/utils/gulp/gulp-tasks-dev.js
+++ b/src/utils/gulp/gulp-tasks-dev.js
@@ -105,16 +105,18 @@ module.exports = function(gulp, options, webpackConfig, dist) {
       }
     });
 
-    var host = options.devServerHost || 'localhost';
+    // Always open on all ports unless overridden
+    var host = options.devServerHost || '0.0.0.0';
 
     server.listen(options.devServerPort || 8080, host, function(err) {
       if (err) {
         console.error('[webpack-dev-server] failed to start:', err);
       } else {
+        var openHost = (host === '0.0.0.0') ? 'localhost' : host;
         console.log('[webpack-dev-server] started: opening the app in your default browser...');
         gulp.src(path.join(dist, 'index.html'))
         .pipe(open({
-          uri: 'http://' + host + ':' + options.devServerPort + '/webpack-dev-server/'
+          uri: 'http://' + openHost + ':' + options.devServerPort + '/webpack-dev-server/'
         }));
       }
     });


### PR DESCRIPTION
This should make dev easier for vagrant and other vm users, without removing the override ability. Also makes it significantly easier to test out on mobile and other devices/browsers on different machines.

Also make gulp open localhost in the browser instead of 0.0.0.0 if the host is 0.0.0.0.