### PR TITLE
Added jsLoader option.

### DIFF
--- a/src/utils/gulp/gulp-tasks.js
+++ b/src/utils/gulp/gulp-tasks.js
@@ -17,17 +17,19 @@ module.exports = function(gulp, opts) {
 
   var dist = options.dist || path.resolve(process.cwd(), 'dist');
 
+  var jsLoader = options.jsLoader || {
+    test: /\.js$/,
+    loader: 'babel',
+    exclude: /(node_modules\/intl|node_modules\/moment|bower_components|src\/lib)/
+  };
+
   var webpackConfig = {
     output: {
       filename: 'index.js'
     },
     module: {
       loaders: [
-        {
-          test: /\.js$/,
-          loader: 'babel',
-          exclude: /(node_modules\/intl|node_modules\/moment|bower_components|src\/lib)/
-        },
+        jsLoader,
         {
           test: /\.json$/,
           loader: 'json-loader'


### PR DESCRIPTION
First, I wanted to support reac-hot-loader. Then, I stumbled upon an error when babel processed some libraries (eg. socket-io). I want to exclude those, or just include specific directories.

I tried to use option `webpack.module.loaders`, but these are always added after default loaders (ie. `devWebpackConfig.module.loaders.push(loader);` at gulp-task-dev.js)

Using this patch, I can add the following option to gulpfile.js:
```
  jsLoader: {
    test: /\.js$/,
    loader: 'react-hot!babel',
    include: [
        path.resolve(__dirname, "src/js"),
        path.resolve(__dirname, "node_modules/grommet/src/js")
    ]
  },
```