### PR TITLE
Fix layout of grommet home page to not show horizontal scroll bar, especially when resizing. See screen shot.

### DIFF
--- a/docs/src/scss/_objects.home.scss
+++ b/docs/src/scss/_objects.home.scss
@@ -15,7 +15,7 @@
   }
 
   @include media-query(palm) {
-    max-width: 100vw;
+    max-width: 100%;
   }
 
   pre {

--- a/src/scss/grommet-core/_objects.box.scss
+++ b/src/scss/grommet-core/_objects.box.scss
@@ -12,10 +12,12 @@
     padding-right: $inuit-base-spacing-unit;
 
     &--full {
+      max-width: 100%;
       width: 100vw;
     }
 
     &--full-horizontal {
+      max-width: 100%;
       width: 100vw;
     }
 
@@ -35,6 +37,7 @@
   @include pad();
 
   &--full {
+    max-width: 100%;
     width: 100vw;
     min-height: 100vh;
     // min-height doesn't work for IE and vertical centering
@@ -43,6 +46,7 @@
   }
 
   &--full-horizontal {
+    max-width: 100%;
     width: 100vw;
   }
 


### PR DESCRIPTION
https://trello.com/c/gytuTCGa/261-fix-layout-of-grommet-home-page-to-not-show-horizontal-scroll-bar-especially-when-resizing-see-screen-shot

The issue was caused my multiple modules having a `width` or `max-width` of `100vw`, which all non-gecko browsers incorrectly interpret to include the scrollbar. More here:

http://caniuse.com/#feat=viewport-units (known issue 7)
http://codepen.io/anon/pen/ZGYNWZ

The solution is to add (or replace with) `max-width: 100%` in most cases. I suggest we update this issue across all affected Grommet SCSS files.