### PR TITLE
Fix button size to be full width on mobile phone screens.

### DIFF
--- a/docs/src/Home.js
+++ b/docs/src/Home.js
@@ -47,7 +47,7 @@ var Home = React.createClass({
         <HomeSection colorIndex="neutral-1">
           <Headline>Create once and deliver everywhere.</Headline>
           <Headline small={true}>Application experiences that look great while solving problems.</Headline>
-          <Menu direction="row" justify="center">
+          <Menu direction="row" justify="center" full="true">
             <Link to="design">
               <Button label="See more examples" onClick={this._onClick} large={true} primary={true} />
             </Link>

--- a/docs/src/Home.js
+++ b/docs/src/Home.js
@@ -62,7 +62,7 @@ var Home = React.createClass({
         <HomeSection colorIndex="neutral-2" texture={'url(img/home_features.png)'}>
           <Headline>So little gets you sooooooo much!</Headline>
           <Headline small={true}>We’ve tried it all in enterprise and we think we’ve got a good foundation.</Headline>
-          <Menu direction="row" justify="center">
+          <Menu direction="row" justify="center" full="true">
             <Link to="develop_architecture">
               <Button label="Our architecture" onClick={this._onClick} large={true} primary={true} />
             </Link>
@@ -76,7 +76,7 @@ var Home = React.createClass({
           <Headline>Ready for your Design Workflow.</Headline>
           <Headline small={true}>All the resources you could possibly need! Sticker sheets, Stencils,
             PSDs, and more.</Headline>
-          <Menu direction="row" justify="center">
+          <Menu direction="row" justify="center" full="true">
             <Link to="design">
               <Button label="Start designing" onClick={this._onClick} large={true} primary={true} />
             </Link>
@@ -112,7 +112,7 @@ var Home = React.createClass({
         <HomeSection colorIndex="neutral-3">
           <Headline>Develop your next project with Grommet.</Headline>
           <Headline small={true}>Let’s get an application on your local environment!</Headline>
-          <Menu direction="row" justify="center">
+          <Menu direction="row" justify="center" full="true">
             <Link to="develop_getstarted">
               <Button label="Start project" onClick={this._onClick} large={true} primary={true} />
             </Link>
@@ -140,7 +140,7 @@ var Home = React.createClass({
           <Headline>Built with the best stuff.</Headline>
           <Headline small={true}>The tools you know and love, all packaged together in one
             easy-to-use solution.</Headline>
-          <Menu direction="row" justify="center">
+          <Menu direction="row" justify="center" full="true">
             <a href="https://github.com/HewlettPackard/grommet">
               <Button label="View project on Github" onClick={this._onClick} large={true} primary={true} />
             </a>
@@ -188,7 +188,7 @@ var Home = React.createClass({
         <HomeSection colorIndex="neutral-2">
           <Headline>Let’s keep in touch!</Headline>
           <Headline small={true}>Follow us on the Grommet blog to get the latest updates.</Headline>
-          <Menu direction="row" justify="center">
+          <Menu direction="row" justify="center" full="true">
             <Link to="develop_getstarted">
               <Button label="Grommet blog" onClick={this._onClick} large={true} primary={true} />
             </Link>

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -164,6 +164,7 @@ var Menu = React.createClass({
     collapse: React.PropTypes.bool, // deprecated, remove in 0.5
     dropAlign: Drop.alignPropType,
     dropColorIndex: React.PropTypes.string,
+    full: React.PropTypes.bool,
     icon: React.PropTypes.node,
     inline: React.PropTypes.bool,
     label: React.PropTypes.string,
@@ -183,6 +184,7 @@ var Menu = React.createClass({
       closeOnClick: true,
       direction: 'column',
       dropAlign: {top: 'top', left: 'left'},
+      full: false,
       pad: 'none',
       small: false,
       responsive: true
@@ -417,6 +419,9 @@ var Menu = React.createClass({
     }
     if (this.props.primary) {
       classes.push(prefix + "--primary");
+    }
+    if (this.props.full) {
+      classes.push(prefix + "--full");
     }
 
     return classes;

--- a/src/scss/grommet-core/_objects.menu.scss
+++ b/src/scss/grommet-core/_objects.menu.scss
@@ -32,6 +32,11 @@
       color: $brand-color-darker;
     }
   }
+  
+  &--full {
+    max-width: 100%;
+    width: 100vw;
+  }
 
   &__control {
     cursor: pointer;
@@ -142,9 +147,17 @@
         > *:not(.control-icon):not(.button) {
           margin-left: 0px;
           margin-right: $inuit-base-spacing-unit;
-
+          
           &:last-child {
             margin-right: 0px;
+          }
+        }
+      }
+      
+      &.box--direction-row.box--responsive {
+        @include media-query(palm) {
+          > * {
+            margin-right: 0;
           }
         }
       }


### PR DESCRIPTION
https://trello.com/c/aljMXJA2/259-fix-button-size-to-be-full-width-on-mobile-phone-screens

Added a `full` attribute on the Menu object, allowing menu and content to be full width.


Also, removed right margin on links inside responsive box for handheld size:
```
@media screen and (max-width: 44.9375em) {
  .menu--inline.menu.box--direction-row.box--responsive > * {
    margin-right: 0;
  }
}
```
Not sure this is the ideal/final solution, but we wanted to avoid adding `className` directly to all links.

![screen shot 2015-09-16 at 6 17 22 pm](https://cloud.githubusercontent.com/assets/2073918/9922579/400a5a5a-5c9f-11e5-901e-11d23f8fb1de.png)
