### PR TITLE
Add ability for intranet header to have two widths (960px) and 100%.

### DIFF
--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -13,6 +13,7 @@ var Header = React.createClass({
   propTypes: merge({
     fixed: React.PropTypes.bool,
     float: React.PropTypes.bool,
+    fullWidth: React.PropTypes.bool,
     large: React.PropTypes.bool,
     size: React.PropTypes.oneOf(['small', 'medium', 'large']),
     small: React.PropTypes.bool,
@@ -25,6 +26,7 @@ var Header = React.createClass({
     return {
       pad: 'none',
       direction: 'row',
+      fullWidth: true,
       align: 'center',
       responsive: false,
       tag: 'header'
@@ -90,6 +92,9 @@ var Header = React.createClass({
       classes.push(CLASS_ROOT + "--float");
       containerClasses.push(CLASS_ROOT + "__container--float");
     }
+    if (this.props.fullWidth) {
+       classes.push(CLASS_ROOT + "--full-width");
+     }
     if (this.state.size) {
       classes.push(CLASS_ROOT + "--" + this.state.size);
     }

--- a/src/scss/grommet-core/_objects.header.scss
+++ b/src/scss/grommet-core/_objects.header.scss
@@ -1,7 +1,13 @@
 // (C) Copyright 2014-2015 Hewlett-Packard Development Company, L.P.
 
 .header {
-  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  width: 960px;
+ 
+  &--full-width {
+     width: 100%;
+  }
 
   &.box {
     > *:not(:last-child) {


### PR DESCRIPTION
https://trello.com/c/iCVhG7Gv/265-add-ability-for-intranet-header-to-have-two-widths-960px-and-100

Header now needs class `header--full-width` to be `100%` width, which is has by default. To remove, set `fullWidth="false"`, which will set the `width` to `960px` and `margin` left and right to `auto`