### PR TITLE
Verify any element that has max-width of 100vw

### DIFF
--- a/src/scss/grommet-core/_objects.form.scss
+++ b/src/scss/grommet-core/_objects.form.scss
@@ -47,7 +47,7 @@
 
     @include media-query(lap-and-up) {
       max-height: 100vh;
-      max-width: 100vw;
+      max-width: 100%;
       overflow: auto;
       padding: round($inuit-base-spacing-unit * 0.75) double($inuit-base-spacing-unit) double($inuit-base-spacing-unit);
     }

--- a/src/scss/grommet-core/_objects.index.scss
+++ b/src/scss/grommet-core/_objects.index.scss
@@ -2,7 +2,7 @@
 
 .index {
   min-width: $sidebar-width;
-  max-width: 100vw;
+  max-width: 100%;
   overflow: auto;
   border-right: 1px solid $strong-border-color;
 

--- a/src/scss/grommet-core/_objects.layer.scss
+++ b/src/scss/grommet-core/_objects.layer.scss
@@ -33,7 +33,7 @@
     @include media-query(lap-and-up) {
       position: absolute;
       max-height: 100vh;
-      max-width: 100vw;
+      max-width: 100%;
       padding: round($inuit-base-spacing-unit * 0.75) double($inuit-base-spacing-unit) double($inuit-base-spacing-unit);
       border-radius: $border-radius;
       box-shadow: $layer-box-shadow;

--- a/src/scss/grommet-core/_objects.menu.scss
+++ b/src/scss/grommet-core/_objects.menu.scss
@@ -288,6 +288,7 @@
 
 @include media-query(palm) {
   .menu__drop {
+    max-width: 100%;
     width: 100vw;
 
     //.menu__control {

--- a/src/scss/grommet-core/_objects.search.scss
+++ b/src/scss/grommet-core/_objects.search.scss
@@ -35,6 +35,7 @@
     @include inuit-font-size($inuit-heading-size-4, inherit);
 
     @include media-query(palm) {
+      max-width: 100%;
       width: 100vw;
     }
 

--- a/src/scss/grommet-core/_objects.sidebar.scss
+++ b/src/scss/grommet-core/_objects.sidebar.scss
@@ -5,6 +5,7 @@
   min-height: 100vh;
 
   @include media-query(palm) {
+    max-width: 100%;
     width: 100vw;
   }
 

--- a/src/scss/grommet-core/_objects.tile.scss
+++ b/src/scss/grommet-core/_objects.tile.scss
@@ -32,8 +32,8 @@
     flex-direction: row;
     -webkit-align-items: center;
     align-items: center;
-    width: 100%;
-    max-width: 100vw;
+    width: 100vw;
+    max-width: 100%;
 
     .tiles__left,
     .tiles__right {


### PR DESCRIPTION
https://trello.com/c/7vPbBNCk/269-verify-any-element-that-has-max-width-of-100vw

After completing https://github.com/HewlettPackard/grommet/pull/187, we discovered there were other modules also affected by the issue of using `width:100vw` without `max-width:100%`. This fix updates all SCSS files in Grommet `src` to resolve the issue. `max-width:100vw` was also updated to `max-width:100%`. 