### PR TITLE
Jslint fix

### DIFF
--- a/src/utils/gulp/gulp-tasks-test.js
+++ b/src/utils/gulp/gulp-tasks-test.js
@@ -33,10 +33,9 @@ module.exports = function(gulp, options) {
             watch(watchFolders, function() {
               gulp.src(options.testPaths, {
                 read: false
-              })
-                .pipe(mocha({
-                  reporter: 'spec'
-                })).once('end', function() {
+              }).pipe(mocha({
+                reporter: 'spec'
+              })).once('end', function() {
                 console.log('Watching for changes...');
               }).on('error', function(err) {
                 console.error('Test failed:', err.stack || err);


### PR DESCRIPTION
This section passes jslint on some installs, but not others. 
eslint under 1.5.0 lets it through, 1.5.0 and later fails on indentation.
The change still works on under 1.5.0 eslint.