### PR TITLE
Moved h1-h5 from objects.header to base.text.scss

### DIFF
--- a/src/scss/grommet-core/_base.text.scss
+++ b/src/scss/grommet-core/_base.text.scss
@@ -5,6 +5,52 @@ body {
   @include inuit-font-size($content-font-size, $inuit-base-spacing-unit);
 }
 
+h1 {
+  @include inuit-font-size(48px);
+}
+
+h2 {
+  @include inuit-font-size(36px);
+}
+
+h3 {
+  // inuit-font-size sets the line-height to 24px when the font size is 24px.
+  // We want a bit more leading between lines than that.
+  @include inuit-font-size(24px, 28px);
+}
+
+h4 {
+  @include inuit-font-size(18px);
+}
+
+h5 {
+  @include inuit-font-size(18px);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5 {
+  font-weight: 100;
+  max-width: 100%;
+
+  &.header--strong,
+  > strong {
+    font-weight: 600;
+  }
+
+  a,
+  a.anchor {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}
+
 p,
 dd,
 li {

--- a/src/scss/grommet-core/_objects.header.scss
+++ b/src/scss/grommet-core/_objects.header.scss
@@ -29,52 +29,6 @@
   }
 }
 
-h1 {
-  @include inuit-font-size(48px);
-}
-
-h2 {
-  @include inuit-font-size(36px);
-}
-
-h3 {
-  // inuit-font-size sets the line-height to 24px when the font size is 24px.
-  // We want a bit more leading between lines than that.
-  @include inuit-font-size(24px, 28px);
-}
-
-h4 {
-  @include inuit-font-size(18px);
-}
-
-h5 {
-  @include inuit-font-size(18px);
-}
-
-h1,
-h2,
-h3,
-h4,
-h5 {
-  font-weight: 100;
-  max-width: 100%;
-
-  &.header--strong,
-  > strong {
-    font-weight: 600;
-  }
-
-  a,
-  a.anchor {
-    color: inherit;
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: none;
-    }
-  }
-}
-
 header.header {
   @include inuit-font-size($header-font-size, inherit);
 


### PR DESCRIPTION
As per my conversation with @ericsoderberghp, the h1-h5 styles don't really belong in the `objects.header` file. I've moved them to `base.text`. This PR directly affects https://github.com/HewlettPackard/grommet-hpe/pull/8 and this should be merged first.