### PR TITLE
fix variable name from "center-content-width" to "center-column-width"

### DIFF
--- a/src/scss/grommet-core/_tools.page.scss
+++ b/src/scss/grommet-core/_tools.page.scss
@@ -2,7 +2,7 @@
 
 @mixin center-content {
   width: 100%;
-  max-width: $center-content-width;
+  max-width: $center-column-width;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
I attempted to use this mixin and got an error because `$center-content-width` was undefined. Based on the purpose of this mixin, I believe the variable was supposed to be `$center-column-width`, which works as expected.